### PR TITLE
EXACT: science decoder and full-size data product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,49 @@
 build
 *.swp
+.vscode
+
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/flight-controller/controller-code/det-controller/Listener.cc
+++ b/flight-controller/controller-code/det-controller/Listener.cc
@@ -132,7 +132,15 @@ Listener::receive_decode_msg() {
     }
 
     else if (cmd_name == "start-nrl-list") {
-        return DetectorMessages::StartNrlList {};
+        return DetectorMessages::StartNrlList {
+            .started = false, .full_size = false
+        };
+    }
+
+    else if (cmd_name == "start-nrl-full-size-list") {
+        return DetectorMessages::StartNrlList {
+            .started = false, .full_size = true
+        };
     }
 
     else if (cmd_name == "stop-nrl-list") {

--- a/flight-controller/controller-code/det-messages/DetectorMessages.hh
+++ b/flight-controller/controller-code/det-messages/DetectorMessages.hh
@@ -97,7 +97,10 @@ namespace DetectorMessages {
     struct RestartTimeSliceCollection { };
     struct ImmediateHafxTimeSliceRead { };
 
-    struct StartNrlList { bool started = false; };
+    struct StartNrlList {
+        bool started = false;
+        bool full_size = false;
+    };
     struct StopNrlList { };
 
     struct __attribute__((packed)) HafxHealth {

--- a/flight-controller/controller-code/det-messages/DetectorMessages.hh
+++ b/flight-controller/controller-code/det-messages/DetectorMessages.hh
@@ -48,6 +48,7 @@ namespace DetectorMessages {
             FpgaWeights,
             Histogram,
             ListMode,
+            FullSizeNrlListMode,
         };
         Type type;
         uint32_t wait_between;

--- a/flight-controller/controller-code/det-service/DetectorService.hh
+++ b/flight-controller/controller-code/det-service/DetectorService.hh
@@ -118,7 +118,7 @@ private:
     void initialize();
     void start_nominal();
     void read_all_time_slices();
-    void start_nrl_list_mode();
+    void start_nrl_list_mode(bool full_size);
     void check_save_nrl_buffers();
     void reconnect_detectors();
     void x123_debug(DetectorMessages::X123Debug);

--- a/flight-controller/controller-code/hafx-ctrl/HafxControl.cc
+++ b/flight-controller/controller-code/hafx-ctrl/HafxControl.cc
@@ -1,4 +1,4 @@
-  #include <HafxControl.hh>
+#include <HafxControl.hh>
 #include <logging.hh>
 #include <sstream>
 
@@ -16,7 +16,8 @@ HafxControl::HafxControl(std::shared_ptr<SipmUsb::UsbManager> driver_, DetectorP
                   DetectorMessages::HafxNominalSpectrumStatus> >(
                   ports.science, SLICES_PER_SECOND)},
     nrl_data_saver{std::make_unique<DataSaver>(ports.science)}, // will need different udp capture flags than time slice nominal
-    debug_saver{std::make_unique<DataSaver>(ports.debug)}
+    debug_saver{std::make_unique<DataSaver>(ports.debug)},
+    save_full_size{false}
 { }
 
 DetectorMessages::HafxHealth HafxControl::generate_health() {
@@ -155,6 +156,10 @@ HafxControl::read_nrl_buffer() {
     return nrl_buff.decode();
 }
 
+void HafxControl::use_full_size(bool full_size) {
+    this->save_full_size = full_size;
+}
+
 void HafxControl::poll_save_nrl_list() {
     /*
      * Check if NRL list buffers 0 and 1 are full,
@@ -162,16 +167,18 @@ void HafxControl::poll_save_nrl_list() {
      * if they are.
      */
     using namespace SipmUsb;
-
+    
     FpgaResults fpga_res_con;
     driver->read(fpga_res_con, MemoryType::ram);
     uint32_t time_after_read = time(NULL);
 
+    // Capture variables by reference into the lambda
     auto save = [&](auto buf_num) {
         auto full = fpga_res_con.nrl_buffer_full(buf_num);
-        if (!full) return;
+        if (!full)
+            return;
         log_debug(std::to_string(buf_num) + " is full");
-#if 1
+
         this->swap_nrl_buffer(buf_num);
         auto data = this->read_nrl_buffer();
         // If there is no PPS in the data,
@@ -184,16 +191,26 @@ void HafxControl::poll_save_nrl_list() {
             log_info("there was no PPS");
             return;
         }
-#endif
-        auto stripped = strip_nrl_data(std::move(data));
-        auto evts_save = std::string{
-            reinterpret_cast<const char*>(stripped.data()),
-            stripped.size() * sizeof(decltype(stripped)::value_type)
-        };
+
+        std::string evts_save;
+        auto num_events = data.size();
+        if (save_full_size) {
+            evts_save = std::string{
+                reinterpret_cast<const char*>(data.data()),
+                data.size() * sizeof(decltype(data)::value_type)
+            };
+        } else {
+            auto stripped = strip_nrl_data(std::move(data));
+            evts_save = std::string{
+                reinterpret_cast<const char*>(stripped.data()),
+                stripped.size() * sizeof(decltype(stripped)::value_type)
+            };
+        }
+
         // Put some metadata into strings to save
         // Never gonna be more than 2048 events;
         // could be fewer but unlikely
-        uint16_t len = static_cast<uint16_t>(stripped.size());
+        uint16_t len = static_cast<uint16_t>(num_events);
         auto size_save = std::string{
             reinterpret_cast<const char*>(&len),
             sizeof(len)};
@@ -201,12 +218,15 @@ void HafxControl::poll_save_nrl_list() {
             reinterpret_cast<const char*>(&time_after_read),
             sizeof(time_after_read)};
 
+        // The data saver we want to use depends on
+        // if we are taking "full-size" data vs not
+        auto &saver = (save_full_size? this->debug_saver : this->nrl_data_saver);
         // Save order:
         // - # of events recorded
         // - data
         // - timestamp immediately after readout
         // save all at once so we don't get misaligned files
-        this->nrl_data_saver->add(size_save + evts_save + timestamp_save);
+        saver->add(size_save + evts_save + timestamp_save);
     };
 
     // Save buffers 0, 1

--- a/flight-controller/controller-code/hafx-ctrl/HafxControl.hh
+++ b/flight-controller/controller-code/hafx-ctrl/HafxControl.hh
@@ -6,6 +6,7 @@
 #include <DetectorMessages.hh>
 
 #include <DetectorSupport.hh>
+#include <functional>
 #include <typeindex>
 #include <unordered_map>
 
@@ -29,6 +30,7 @@ public:
     void restart_trace();
     bool check_trace_done();
     void swap_nrl_buffer(uint8_t buf_num);
+    void use_full_size(bool full_size);
     void poll_save_nrl_list();
     void poll_save_time_slice();
 
@@ -53,6 +55,9 @@ private:
     std::unique_ptr<QueuedDataSaver<science_t> > science_saver;
     std::unique_ptr<DataSaver> nrl_data_saver;
     std::unique_ptr<DataSaver> debug_saver;
+
+    // Do we want to save full-size NRL data?
+    bool save_full_size;
 
     DetectorMessages::HafxNominalSpectrumStatus
     read_time_slice();

--- a/flight-controller/controller-code/hafx-ctrl/tests/test_hafx_ctrl.cc
+++ b/flight-controller/controller-code/hafx-ctrl/tests/test_hafx_ctrl.cc
@@ -176,15 +176,12 @@ TEST(HafxCtrl, DebugCollections) {
     ctrl->read_save_debug<SipmUsb::ArmCal>();
 }
 
-TEST(HafxCtrl, SwapBuffer) {
+TEST(HafxCtrl, FillBothBuffersAndRead) {
     auto ctrl = get_test_hafx_ctrl();
-    //see if it can read out registers, swap one bit and write back
-    // could need to make this test better
-    ctrl->swap_nrl_buffer(0);
-    ctrl->swap_nrl_buffer(1);
-    ctrl->swap_nrl_buffer(0);
-    ctrl->swap_nrl_buffer(1);
-    ctrl->swap_nrl_buffer(1);
+
+    // idk if a test here is necessary. The only thing it would 
+    // differently that the test in sipm3k is test 'poll_save_nrl_list
+    
 }
 
 int main(int argc, char *argv[]) {

--- a/lab-scripts/data-collection/exact_specific/nrl_full_size_list.bash
+++ b/lab-scripts/data-collection/exact_specific/nrl_full_size_list.bash
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Start NRL list mode data acquisition.
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 [acquisition time in second]"
+    exit 1
+fi
+
+bash ../check_running.bash || exit 1
+
+# For health port and UDP device
+source ../udpcap_ports.bash
+
+acq_time="$1"
+
+echo "wake" > $det_udp_dev
+
+# Start real data acquisition
+echo "start-nrl-FULL-SIZE-list" > $det_udp_dev
+sleep $(( $acq_time + 2 ))
+
+# Clean up
+echo "stop-nrl-list" > $det_udp_dev
+echo "sleep" > $det_udp_dev

--- a/lab-scripts/data-collection/exact_specific/nrl_launch_udp_caps.bash
+++ b/lab-scripts/data-collection/exact_specific/nrl_launch_udp_caps.bash
@@ -30,10 +30,10 @@ for port in "${!nom_ports_names[@]}"; do
         -p "$post_process_cmd" &
 done
 
-dbg_ports_names=( [$HAFX_C1_DBG_PORT]='hafx-debug-c1' \
-    [$HAFX_M1_DBG_PORT]='hafx-debug-m1' \
-    [$HAFX_M5_DBG_PORT]='hafx-debug-m5' \
-    [$HAFX_X1_DBG_PORT]='hafx-debug-x1')
+dbg_ports_names=( [$HAFX_C1_DBG_PORT]='hafx-nrl-debug-c1' \
+    [$HAFX_M1_DBG_PORT]='hafx-nrl-debug-m1' \
+    [$HAFX_M5_DBG_PORT]='hafx-nrl-debug-m5' \
+    [$HAFX_X1_DBG_PORT]='hafx-nrl-debug-x1')
 for port in "${!dbg_ports_names[@]}"; do
     # -t argument: Only wait 1s after a read to save the file
     udp_capture -m 60000 \
@@ -45,4 +45,4 @@ for port in "${!dbg_ports_names[@]}"; do
 done
 
 # Health listener
-udp_capture -m 60000 -T "$default_timeout" -t "$default_timeout" -l "$DET_HEALTH_PORT" -b "live/detector-health" -p "$post_process_cmd" &
+udp_capture -m 60000 -T "$default_timeout" -t "$default_timeout" -l "$DET_HEALTH_PORT" -f 10.133.225.126:61010 -b "live/detector-health" -p "$post_process_cmd" &

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,3 +37,5 @@ decode-impress-hafx = "umndet.ground.json_decoders:decode_hafx_sci"
 decode-hafx-debug-hist = "umndet.ground.json_decoders:decode_hafx_debug_hist"
 
 decode-x123-science = "umndet.ground.json_decoders:decode_x123_sci"
+
+decode-exact-science = "umndet.ground.json_decoders:decode_exact_sci"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,3 +39,4 @@ decode-hafx-debug-hist = "umndet.ground.json_decoders:decode_hafx_debug_hist"
 decode-x123-science = "umndet.ground.json_decoders:decode_x123_sci"
 
 decode-exact-science = "umndet.ground.json_decoders:decode_exact_sci"
+decode-exact-debug = "umndet.ground.json_decoders:decode_full_size_exact_sci"

--- a/python/umndet/common/helpers.py
+++ b/python/umndet/common/helpers.py
@@ -105,7 +105,24 @@ def read_stripped_nrl_list(fn: str, open_func: Callable) -> list:
         return {'unix_time': timestamp, 'events': evts}
     return generic_read_binary(fn, open_func, read_element)
 
-# TODO: add full size nrl list reader
+def read_full_nrl_list(fn: str, open_func: Callable) -> list:
+    '''
+    Read a file full of full file of full fill nrl data mode list
+    orignal format :)
+    Contains all the data as defined by:
+    https://drive.google.com/file/d/13mLWfhBhoJyiL4Ph0IBVupMZWh-V8y1D/view
+    '''
+    def read_element(f: IO[bytes]):
+        num_events, = struct.unpack('<H', f.read(2))
+        evts = []
+        for _ in range(num_events):
+            d = ies.FullSizeNrlDataPoint()
+            f.readinto(d)
+            evts.append(d)
+        timestamp, = struct.unpack('<L', f.read(4))
+        return {'unix_time': timestamp, 'events': evts}
+    return generic_read_binary(fn, open_func, read_element)
+    
 
 def reverse_bridgeport_mapping(adc_mapping: Iterable[int]) -> list[int]:
     '''

--- a/python/umndet/common/helpers.py
+++ b/python/umndet/common/helpers.py
@@ -105,6 +105,7 @@ def read_stripped_nrl_list(fn: str, open_func: Callable) -> list:
         return {'unix_time': timestamp, 'events': evts}
     return generic_read_binary(fn, open_func, read_element)
 
+# TODO: add full size nrl list reader
 
 def reverse_bridgeport_mapping(adc_mapping: Iterable[int]) -> list[int]:
     '''

--- a/python/umndet/common/impress_exact_structs.py
+++ b/python/umndet/common/impress_exact_structs.py
@@ -1,4 +1,5 @@
 import base64
+from io import BytesIO
 import ctypes
 import struct
 
@@ -234,6 +235,9 @@ class HafxDebug:
         ('fpga_weights', '<1024H'),
         ('histogram', '<4096L'),
         ('listmode', '<1024H'),
+        # The NRL list mode data is variable-size,
+        # so we need to handle it as a special case
+        ('nrl_list_full_size', NotImplemented),
     ]
 
     def __init__(self, debug_type: int, debug_bytes: bytes):
@@ -242,12 +246,28 @@ class HafxDebug:
 
     def decode(self) -> dict[str, object]:
         type_, unpack_str = HafxDebug.TYPE_DECODE_MAP[self.type]
-        return {
-            'type': type_,
-            'registers': list(
-                struct.unpack(unpack_str, self.bytes)
-            )
-        }
+        if type_ != 'nrl_list_full_size':
+            return {
+                'type': type_,
+                'registers': list(
+                    struct.unpack(unpack_str, self.bytes)
+                )
+            }
+
+        # change if we add more weird types
+        assert type_ == 'nrl_list_full_size'
+        # NRL full size list
+        f = BytesIO(self.bytes)
+        num_events, = struct.unpack('<H', f.read(2))
+        evts = []
+        for _ in range(num_events):
+            d = FullSizeNrlDataPoint()
+            f.readinto(d)
+            evts.append(d)
+        timestamp, = struct.unpack('<L', f.read(4))
+        return {'type': type_,
+                'data': {'unix_time': timestamp, 'events': evts}}
+
 
 class FullSizeNrlDataPoint(ctypes.LittleEndianStructure):
     NS_PER_TICK = 25
@@ -256,12 +276,12 @@ class FullSizeNrlDataPoint(ctypes.LittleEndianStructure):
         ('psd', ctypes.c_uint16),
         ('energy', ctypes.c_uint16),
         ('relative_timestamp', ctypes.c_uint64, 51), # this is literally 14.3 years of range with
-        ('external_trigger', ctypes.c_uint32, 1), # 200ns ticks, what the flip, who's idea was that
-        ('piled_up', ctypes.c_uint32, 1),
-        ('over_flow', ctypes.c_uint32, 1),
-        ('out_of_range', ctypes.c_uint32, 1),
-        ('was_pps', ctypes.c_uint32, 1),
-        ('padding', ctypes.c_uint32, 8),
+        ('external_trigger', ctypes.c_uint64, 1), # 200ns ticks, what the flip, who's idea was that
+        ('piled_up', ctypes.c_uint64, 1),
+        ('over_flow', ctypes.c_uint64, 1),
+        ('out_of_range', ctypes.c_uint64, 1),
+        ('was_pps', ctypes.c_uint64, 1),
+        ('padding', ctypes.c_uint64, 8),
     )
 
     def to_json(self):

--- a/python/umndet/common/impress_exact_structs.py
+++ b/python/umndet/common/impress_exact_structs.py
@@ -249,8 +249,25 @@ class HafxDebug:
             )
         }
 
+class FullSizeNrlData(ctypes.LittleEndianStructure):
+    NS_PER_TICK = 200
+    _pack_ = 1
+    _fields_ = (
+        ('relative_timestamp', ctypes.c_uint64, 51),
+        ('energy', ctypes.c_uint16),
+        ('psd', ctypes.c_uint16),
+        ('was_pps', ctypes.c_uint32, 1),
+        ('piled_up', ctypes.c_uint32, 1),
+        ('out_of_range', ctypes.c_uint32, 1),
+        ('over_flow', ctypes.c_uint32, 1),
+        ('external_trigger', ctypes.c_uint32, 1),
+    )
+
+    def to_json(self):
+        return {field[0]: getattr(self, field[0]) for field in self._fields_}
 
 class StrippedNrlDataPoint(ctypes.LittleEndianStructure):
+    NS_PER_TICK = 200
     _pack_ = 1
     _fields_ = (
         ('relative_timestamp', ctypes.c_uint32, 25),

--- a/python/umndet/common/impress_exact_structs.py
+++ b/python/umndet/common/impress_exact_structs.py
@@ -249,18 +249,19 @@ class HafxDebug:
             )
         }
 
-class FullSizeNrlData(ctypes.LittleEndianStructure):
-    NS_PER_TICK = 200
+class FullSizeNrlDataPoint(ctypes.LittleEndianStructure):
+    NS_PER_TICK = 25
     _pack_ = 1
     _fields_ = (
-        ('relative_timestamp', ctypes.c_uint64, 51),
-        ('energy', ctypes.c_uint16),
         ('psd', ctypes.c_uint16),
-        ('was_pps', ctypes.c_uint32, 1),
+        ('energy', ctypes.c_uint16),
+        ('relative_timestamp', ctypes.c_uint64, 51), # this is literally 14.3 years of range with
+        ('external_trigger', ctypes.c_uint32, 1), # 200ns ticks, what the flip, who's idea was that
         ('piled_up', ctypes.c_uint32, 1),
-        ('out_of_range', ctypes.c_uint32, 1),
         ('over_flow', ctypes.c_uint32, 1),
-        ('external_trigger', ctypes.c_uint32, 1),
+        ('out_of_range', ctypes.c_uint32, 1),
+        ('was_pps', ctypes.c_uint32, 1),
+        ('padding', ctypes.c_uint32, 8),
     )
 
     def to_json(self):

--- a/python/umndet/common/impress_exact_structs.py
+++ b/python/umndet/common/impress_exact_structs.py
@@ -260,3 +260,5 @@ class StrippedNrlDataPoint(ctypes.LittleEndianStructure):
         ('out_of_range', ctypes.c_uint32, 1),
     )
 
+    def to_json(self):
+        return {field[0]: getattr(self, field[0]) for field in self._fields_}

--- a/python/umndet/common/impress_exact_structs.py
+++ b/python/umndet/common/impress_exact_structs.py
@@ -275,8 +275,9 @@ class FullSizeNrlDataPoint(ctypes.LittleEndianStructure):
     _fields_ = (
         ('psd', ctypes.c_uint16),
         ('energy', ctypes.c_uint16),
-        ('relative_timestamp', ctypes.c_uint64, 51), # this is literally 14.3 years of range with
-        ('external_trigger', ctypes.c_uint64, 1), # 200ns ticks, what the flip, who's idea was that
+        # Up to about 2 years of timestamps
+        ('relative_timestamp', ctypes.c_uint64, 51),
+        ('external_trigger', ctypes.c_uint64, 1),
         ('piled_up', ctypes.c_uint64, 1),
         ('over_flow', ctypes.c_uint64, 1),
         ('out_of_range', ctypes.c_uint64, 1),
@@ -300,3 +301,4 @@ class StrippedNrlDataPoint(ctypes.LittleEndianStructure):
 
     def to_json(self):
         return {field[0]: getattr(self, field[0]) for field in self._fields_}
+


### PR DESCRIPTION
Adds a few features
- JSON (ground) decoders for EXACT science data
- Full-size (debug) data product for EXACT list mode
    - You can query the full-size NRL list mode with a separate command
    - You read it in with the `read_hafx_debug` function in the `umndet` module
- Tests for the full-size list mode (C++)