### PR TITLE
Add all channel histogram debug option

### DIFF
--- a/flight-controller/controller-code/det-controller/Listener.cc
+++ b/flight-controller/controller-code/det-controller/Listener.cc
@@ -264,7 +264,8 @@ DetectorMessages::DetectorCommand Listener::hafx_debug() {
 
     bool do_wait = (
         type == "histogram" || type == "list_mode" ||
-        type == "nrl_list_mode" || type == "time_slice"
+        type == "nrl_list_mode" || type == "time_slice" ||
+	type == "all_channel_histogram"
     );
     if (do_wait && (wait == 0 || wait > MAX_WAIT_TIME_SEC)) {
         log_debug("maybe waiting for " + std::to_string(wait));

--- a/flight-controller/controller-code/det-controller/Listener.cc
+++ b/flight-controller/controller-code/det-controller/Listener.cc
@@ -282,6 +282,7 @@ DetectorMessages::DetectorCommand Listener::hafx_debug() {
     else if (type == "fpga_statistics"        ) t = dbg_t::Type::FpgaStatistics;
     else if (type == "fpga_weights"           ) t = dbg_t::Type::FpgaWeights;
     else if (type == "histogram"              ) t = dbg_t::Type::Histogram;
+    else if (type == "all_channel_histogram"  ) t = dbg_t::Type::AllChannelHistogram;
     else if (type == "list_mode"              ) t = dbg_t::Type::ListMode;
     else throw DetectorException{"Ill-formed debug request type '" + type + "'"};
 

--- a/flight-controller/controller-code/det-messages/DetectorMessages.hh
+++ b/flight-controller/controller-code/det-messages/DetectorMessages.hh
@@ -49,6 +49,7 @@ namespace DetectorMessages {
             Histogram,
             ListMode,
             FullSizeNrlListMode,
+	    AllChannelHistogram,
         };
         Type type;
         uint32_t wait_between;
@@ -91,6 +92,7 @@ namespace DetectorMessages {
     struct QueryLegacyHistogram { DetectorMessages::HafxChannel ch; };
     struct QueryListMode { DetectorMessages::HafxChannel ch; };
     struct QueryX123DebugHistogram { };
+    struct QueryAllChannelLegacyHistogram{ };
 
     struct ImmediateX123BufferRead { };
     struct RestartX123SequentialBuffering { };

--- a/flight-controller/controller-code/det-service/DetectorService.cc
+++ b/flight-controller/controller-code/det-service/DetectorService.cc
@@ -286,7 +286,18 @@ void DetectorService::handle_command(dm::HafxDebug cmd) {
         );
     }
     else if (acq_type == dbr_t::Type::AllChannelHistogram) {
-        ctrl->restart_time_slice_or_histogram();
+	if (hafx_ctrl.contains(dm::HafxChannel::C1)) {
+	    hafx_ctrl[dm::HafxChannel::C1]->restart_time_slice_or_histogram();
+	}
+	if (hafx_ctrl.contains(dm::HafxChannel::M1)) {
+	    hafx_ctrl[dm::HafxChannel::M1]->restart_time_slice_or_histogram();
+	}
+	if (hafx_ctrl.contains(dm::HafxChannel::M5)) {
+	    hafx_ctrl[dm::HafxChannel::M5]->restart_time_slice_or_histogram();
+	}
+	if (hafx_ctrl.contains(dm::HafxChannel::X1)) {
+	    hafx_ctrl[dm::HafxChannel::X1]->restart_time_slice_or_histogram();
+	}
         hafx_debug_hist_timer = TimerLifetime::create(
             queue.push_delay(dm::QueryAllChannelLegacyHistogram{}, delay)
         );
@@ -361,15 +372,21 @@ void DetectorService::handle_command(dm::QueryLegacyHistogram cmd) {
 }
 
 void DetectorService::handle_command(dm::QueryAllChannelLegacyHistogram) {
+
     using hg_t = SipmUsb::FpgaHistogram;
-    if (hafx_ctrl.contains(dm::HafxChannel::C1))
-        hafx_ctrl[dm::HafxChannel::C1]->read_save_debug<hg_t>();
-    if (hafx_ctrl.contains(dm::HafxChannel::M1))
+
+    if (hafx_ctrl.contains(dm::HafxChannel::C1)) {
+    	hafx_ctrl[dm::HafxChannel::C1]->read_save_debug<hg_t>();
+    }
+    if (hafx_ctrl.contains(dm::HafxChannel::M1)) {
 	hafx_ctrl[dm::HafxChannel::M1]->read_save_debug<hg_t>();
-    if (hafx_ctrl.contains(dm::HafxChannel::M5))
+    }
+    if (hafx_ctrl.contains(dm::HafxChannel::M5)) {
 	hafx_ctrl[dm::HafxChannel::M5]->read_save_debug<hg_t>();
-    if (hafx_ctrl.contains(dm::HafxChannel::X1))
+    }
+    if (hafx_ctrl.contains(dm::HafxChannel::X1)) {
 	hafx_ctrl[dm::HafxChannel::X1]->read_save_debug<hg_t>();
+    }
 }
 
 void DetectorService::handle_command(dm::QueryX123DebugHistogram) {

--- a/flight-controller/controller-code/det-service/DetectorService.cc
+++ b/flight-controller/controller-code/det-service/DetectorService.cc
@@ -285,6 +285,12 @@ void DetectorService::handle_command(dm::HafxDebug cmd) {
             queue.push_delay(dm::QueryListMode{cmd.ch}, delay)
         );
     }
+    else if (acq_type == dbr_t::Type::AllChannelHistogram) {
+        ctrl->restart_time_slice_or_histogram();
+        hafx_debug_hist_timer = TimerLifetime::create(
+            queue.push_delay(dm::QueryAllChannelLegacyHistogram{}, delay)
+        );
+    }
 }
 
 void DetectorService::handle_command(dm::X123Debug cmd) {
@@ -352,6 +358,18 @@ void DetectorService::handle_command(dm::QueryListMode cmd) {
 void DetectorService::handle_command(dm::QueryLegacyHistogram cmd) {
     using hg_t = SipmUsb::FpgaHistogram;
     hafx_ctrl.at(cmd.ch)->read_save_debug<hg_t>();
+}
+
+void DetectorService::handle_command(dm::QueryAllChannelLegacyHistogram) {
+    using hg_t = SipmUsb::FpgaHistogram;
+    if (hafx_ctrl.contains(dm::HafxChannel::C1))
+        hafx_ctrl[dm::HafxChannel::C1]->read_save_debug<hg_t>();
+    if (hafx_ctrl.contains(dm::HafxChannel::M1))
+	hafx_ctrl[dm::HafxChannel::M1]->read_save_debug<hg_t>();
+    if (hafx_ctrl.contains(dm::HafxChannel::M5))
+	hafx_ctrl[dm::HafxChannel::M5]->read_save_debug<hg_t>();
+    if (hafx_ctrl.contains(dm::HafxChannel::X1))
+	hafx_ctrl[dm::HafxChannel::X1]->read_save_debug<hg_t>();
 }
 
 void DetectorService::handle_command(dm::QueryX123DebugHistogram) {

--- a/flight-controller/controller-code/det-service/DetectorService.hh
+++ b/flight-controller/controller-code/det-service/DetectorService.hh
@@ -29,6 +29,7 @@ public:
         DetectorMessages::QueryListMode,
         DetectorMessages::QueryTraceAcquisition,
         DetectorMessages::QueryLegacyHistogram,
+	DetectorMessages::QueryAllChannelLegacyHistogram,
         DetectorMessages::QueryX123DebugHistogram,
 
         DetectorMessages::StartPeriodicHealth,
@@ -100,6 +101,7 @@ private:
     void handle_command(DetectorMessages::X123Debug cmd);
     void handle_command(DetectorMessages::QueryTraceAcquisition cmd);
     void handle_command(DetectorMessages::QueryLegacyHistogram cmd);
+    void handle_command(DetectorMessages::QueryAllChannelLegacyHistogram cmd);
     void handle_command(DetectorMessages::QueryListMode cmd);
     void handle_command(DetectorMessages::QueryX123DebugHistogram cmd);
     void handle_command(DetectorMessages::StopNominal cmd);

--- a/lab-scripts/data-collection/hafx_all_channel_histogram.bash
+++ b/lab-scripts/data-collection/hafx_all_channel_histogram.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Take a "debug" histogram acquisition for a Bridgeport detector with the flight controller programs.
+# First argument: acquisition time
+# Second argument: detector identifier to use (c1, m1, m5, x1)
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 [acquisition time in second] [detector identifier]"
+    exit 1
+fi
+
+
+bash check_running.bash || exit 1
+
+acq_time="$1"
+det="$2"
+source udpcap_ports.bash
+echo "wake" > $det_udp_dev
+echo "debug hafx $det all_channel_histogram $acq_time" > $det_udp_dev
+sleep $(($acq_time + 1))
+echo "sleep" > $det_udp_dev


### PR DESCRIPTION
New debug options that takes debug histograms for all connected (and in envars) SiPM-3k boards