### PR TITLE
Use final assignment in when setting MODE in udev rule

### DIFF
--- a/flight-controller/controller-code/install/10-bridgeport.rules
+++ b/flight-controller/controller-code/install/10-bridgeport.rules
@@ -1,2 +1,2 @@
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fa4", ATTRS{idProduct}=="0203", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fa4", ATTRS{idProduct}=="0203", MODE:="0666"
 

--- a/flight-controller/controller-code/install/11-dp5.rules
+++ b/flight-controller/controller-code/install/11-dp5.rules
@@ -1,2 +1,2 @@
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="842a", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="842a", MODE:="0666"
 


### PR DESCRIPTION
This prevents any system default rules from overwriting the MODE we set, so that we don't need to run "udevadm trigger"